### PR TITLE
Issue-4: npm WARN <library>@<version> dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "keywords"      : ["math", "integer", "int64"],
   "author"        : "Robert Kieffer <robert@broofa.com>",
   "contributors"  : [],
-  "dependencies"  : [],
+  "dependencies"  : {},
   "lib"           : ".",
   "main"          : "./Int64.js",
   "version"       : "0.3.0"


### PR DESCRIPTION
Fixes issue with dependencies listed as an array instead of a hash.

Error:
    "Remove "npm WARN <library>@<version> dependencies field should be
     hash of <name>:<version-range> pairs"
