### PR TITLE
added repository to supress no repo warn

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,5 +8,9 @@
   "dependencies"  : {},
   "lib"           : ".",
   "main"          : "./Int64.js",
-  "version"       : "0.3.0"
+  "version"       : "0.3.0",
+  "repository":
+    { "type" : "git",
+      "url" : "https://github.com/broofa/node-int64"
+    }
 }


### PR DESCRIPTION
npm issues a WARN due to the missing repository field in the package.json. This patch adds it.  
