### PR TITLE
add toJSON function

### DIFF
--- a/Int64.js
+++ b/Int64.js
@@ -26,7 +26,7 @@
  * For details about IEEE-754 see:
  * http://en.wikipedia.org/wiki/Double_precision_floating-point_format
  */
-
+var biginteger = require('biginteger');
 // Useful masks and values for bit twiddling
 var MASK31 =  0x7fffffff, VAL31 = 0x80000000;
 var MASK32 =  0xffffffff, VAL32 = 0x100000000;
@@ -187,11 +187,11 @@ Int64.prototype = {
    * @param radix Just like Number#toString()'s radix
    */
   toString: function(radix) {
-    return this.valueOf().toString(radix || 10);
+    return biginteger.BigInteger.parse(this.toOctetString(), 16).toString(radix || 10);
   },
 
-  toJSON: function(radix){
-    return this.toNumber(false);
+  toJSON: function () {
+    return biginteger.BigInteger.parse(this.toOctetString(), 16).toString(10);
   },
 
   /**

--- a/Int64.js
+++ b/Int64.js
@@ -190,6 +190,10 @@ Int64.prototype = {
     return this.valueOf().toString(radix || 10);
   },
 
+  toJSON: function(radix){
+    return this.valueOf().toString(radix || 10);
+  },
+
   /**
    * Return a string showing the buffer octets, with MSB on the left.
    *

--- a/Int64.js
+++ b/Int64.js
@@ -191,7 +191,7 @@ Int64.prototype = {
   },
 
   toJSON: function(radix){
-    return this.valueOf().toString(radix || 10);
+    return this.toNumber(false);
   },
 
   /**

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   ],
   "author": "Robert Kieffer <robert@broofa.com>",
   "contributors": [],
-  "dependencies": {},
+  "dependencies": {
+    "biginteger": "^1.0.3"
+  },
   "license": "MIT",
   "lib": ".",
   "main": "./Int64.js",


### PR DESCRIPTION
In this PR,add toJSON function.
Without `toJSON` function,once invoke `JSON.stringify`,it will return like

``` js
{buffer: {type: "Buffer", data: [0, 0, 0, 0, 85, 93, 158, 131]}, offset: 0}
```
